### PR TITLE
Switch to Maven Central for Spymemcached dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,32 +25,7 @@ As such, you can confidently use it, the API is small and locked down.
 
 ### Artifact Repositories
 
-Spyglass artifacts are [released to Clojars](https://clojars.org/clojurewerkz/spyglass). Spyglass relies on a recent SpyMemcached release so
-you may need to add [SpyMemcached repository](https://code.google.com/p/spymemcached/wiki/Maven) first.
-
-
-With Leiningen:
-
-``` clojure
-;; in project.clj
-:repositories {"spy-memcached" {:url "http://files.couchbase.com/maven2/"}}
-```
-
-With Maven:
-
-``` xml
-<repositories>
-  <repository>
-    <id>spy</id>
-    <name>Spy Repository</name>
-    <layout>default</layout>
-    <url>http://files.couchbase.com/maven2/</url>
-    <snapshots>
-      <enabled>false</enabled>
-    </snapshots>
-  </repository>
-</repositories>
-```
+Spyglass artifacts are [released to Clojars](https://clojars.org/clojurewerkz/spyglass).
 
 ### The Most Recent Release
 

--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,7 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [net.spy/spymemcached "2.11.4"]
                  [com.couchbase.client/java-client "2.0.0"]]
-  :repositories {"spy-memcached" {:url "http://files.couchbase.com/maven2/"}
-                 "sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
+  :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
                              :snapshots false
                              :releases {:checksum :fail :update :always}}
                  "sonatype-snapshots" {:url "http://oss.sonatype.org/content/repositories/snapshots"


### PR DESCRIPTION
Removes dependency on Couchbase Maven repository and updates the README.