### PR TITLE
Updated dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /classes
 /checkouts
 pom.xml
+pom.xml.*
 *.jar
 *.class
 .lein-*

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojurewerkz/spyglass "1.2.0-SNAPSHOT"
+(defproject timgluz/spyglass "1.2.0"
   :description "A Clojure client for Memcached implemented as a very thin layer on top of SpyMemcached"
   :url "http://github.com/clojurewerkz/spyglass"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,9 @@
-(defproject timgluz/spyglass "1.2.0"
+(defproject clojurewerkz/spyglass "1.2.0-SNAPSHOT"
   :description "A Clojure client for Memcached implemented as a very thin layer on top of SpyMemcached"
   :url "http://github.com/clojurewerkz/spyglass"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [
-                 ;[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
                  [net.spy/spymemcached "2.12.0"]
                  [com.couchbase.client/java-client "2.2.4"]]
   :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
@@ -22,7 +21,7 @@
                    :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
                    :master {:dependencies [[org.clojure/clojure "1.8.0"]]}
                    :dev {:resource-paths ["test/resources"]
-                         :dependencies [[org.clojure/core.cache "0.6.2" :exclusions [org.clojure/clojure]]]
+                         :dependencies [[org.clojure/core.cache "0.6.4" :exclusions [org.clojure/clojure]]]
                          :plugins [[codox "0.8.10"]]
                          :codox {:sources ["src/clojure"]
                                  :output-dir "doc/api"}}}

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,10 @@
   :url "http://github.com/clojurewerkz/spyglass"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [net.spy/spymemcached "2.11.4"]
-                 [com.couchbase.client/java-client "2.0.0"]]
+  :dependencies [
+                 ;[org.clojure/clojure "1.6.0"]
+                 [net.spy/spymemcached "2.12.0"]
+                 [com.couchbase.client/java-client "2.2.4"]]
   :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
                              :snapshots false
                              :releases {:checksum :fail :update :always}}
@@ -15,7 +16,8 @@
   :source-paths      ["src/clojure"]
   :java-source-paths ["src/java"]
   :javac-options     ["-target" "1.8" "-source" "1.8"]
-  :warn-on-reflection true
+  :global-vars {*warn-on-reflection* true
+                *assert* false}
   :profiles       {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
                    :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
                    :master {:dependencies [[org.clojure/clojure "1.8.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -14,11 +14,11 @@
                                        :releases {:checksum :fail :update :always}}}
   :source-paths      ["src/clojure"]
   :java-source-paths ["src/java"]
-  :javac-options     ["-target" "1.6" "-source" "1.6"]
+  :javac-options     ["-target" "1.8" "-source" "1.8"]
   :warn-on-reflection true
   :profiles       {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
                    :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-                   :master {:dependencies [[org.clojure/clojure "1.8.0-master-SNAPSHOT"]]}
+                   :master {:dependencies [[org.clojure/clojure "1.8.0"]]}
                    :dev {:resource-paths ["test/resources"]
                          :dependencies [[org.clojure/core.cache "0.6.2" :exclusions [org.clojure/clojure]]]
                          :plugins [[codox "0.8.10"]]

--- a/test/clojurewerkz/spyglass/test/cache_test.clj
+++ b/test/clojurewerkz/spyglass/test/cache_test.clj
@@ -4,7 +4,10 @@
   (:import [clojure.core.cache BasicCache FIFOCache LRUCache TTLCache]
            java.util.UUID))
 
-(def tc (c/text-connection "localhost:11211"))
+(def memcached-host (or (System/getenv "MEMCACHED_HOST")
+                        "localhost:11211"))
+
+(def tc (c/text-connection memcached-host))
 (c/set-log-level! "WARNING")
 
 (deftest ^{:cache true}

--- a/test/clojurewerkz/spyglass/test/client_test.clj
+++ b/test/clojurewerkz/spyglass/test/client_test.clj
@@ -4,9 +4,11 @@
 
 (def ci? (System/getenv "CI"))
 
+(def memcached-host (or (System/getenv "MEMCACHED_HOST")
+                        "localhost:11211"))
 
-(def tc (c/text-connection "localhost:11211"))
-(def bc (c/bin-connection  "localhost:11211"))
+(def tc (c/text-connection memcached-host))
+(def bc (c/bin-connection  memcached-host))
 
 (c/set-log-level! "WARNING")
 

--- a/test/clojurewerkz/spyglass/test/common_test.clj
+++ b/test/clojurewerkz/spyglass/test/common_test.clj
@@ -6,10 +6,11 @@
 
 
 (def ci? (System/getenv "CI"))
+(def memcached-host (or (System/getenv "MEMCACHED_HOST")
+                        "localhost:11211"))
 
-
-(def tc (c/text-connection "localhost:11211"))
-(def bc (c/bin-connection  "localhost:11211"))
+(def tc (c/text-connection memcached-host))
+(def bc (c/bin-connection  memcached-host))
 (c/set-log-level! "WARNING")
 
 ;;

--- a/test/clojurewerkz/spyglass/test/configurable_connection_test.clj
+++ b/test/clojurewerkz/spyglass/test/configurable_connection_test.clj
@@ -4,6 +4,8 @@
   (:import [net.spy.memcached FailureMode]))
 
 (c/set-log-level! "WARNING")
+(def memcached-host (or (System/getenv "MEMCACHED_HOST")
+                        "localhost:11211"))
 
 (deftest test-to-failure-mode
   (are [alias mode] (is (= (c/to-failure-mode alias) mode))
@@ -22,6 +24,8 @@
     (is (= FailureMode/Cancel (.getFailureMode cf)))))
 
 (deftest test-connection-with-custom-failure-mode
-  (let [conn (c/text-connection "127.0.0.1:11211" (c/text-connection-factory :failure-mode :redistribute))]
+  (let [conn (c/text-connection 
+               memcached-host
+               (c/text-connection-factory :failure-mode :redistribute))]
     (c/set conn "abc000" 3000 "1")
     (is (= (c/get conn "abc000") "1"))))


### PR DESCRIPTION
Hi,

I hit into problem on EC2: Spyglass client lost connection to ElasticCache and reconnection took too long and failed with exception - i did some google-fu and found this issue is now fixed in 2.12.0, according to this CouchBase [codereview tool](http://review.couchbase.org/#/c/42925/)

My changes:

* updated `spymemcached` from 2.11.4 -> 2.12.0 
* updated `com.couchbase.client/java-client` from 2.0.0 -> 2.2.4
* updated `org.clojure/core.cache` from 0.6.2 -> 0.6.4
* i'm using jvm8, so i updated javac also to 1.8;
* upgraded Clojure version in the `master` profile;
* updated  *warn-on-reflection* setting in project.clj to work with newest Leiningen;
* made little tweaks in the test, to make switching memcached server easier;

I'm going test my changes on my services to see did my updates fixed this re-connection issue, that means i'm not very big hurry to get next release out, but it would nice to get some feedback to my pull request if there's something to make it better;