### PR TITLE
Allow to set setTimeoutExceptionThreshold on the Connection factory

### DIFF
--- a/src/clojure/clojurewerkz/spyglass/client.clj
+++ b/src/clojure/clojurewerkz/spyglass/client.clj
@@ -36,7 +36,7 @@
     (to-failure-mode (name input))))
 
 (defn- ^ConnectionFactory customize-factory
-  [^ConnectionFactory cf {:keys [failure-mode transcoder auth-descriptor]}]
+  [^ConnectionFactory cf {:keys [failure-mode transcoder auth-descriptor timeout-exception-threshold]}]
   (let [;; Houston, we have a *FactoryFactory here!
         cfb (ConnectionFactoryBuilder. cf)]
     (when failure-mode
@@ -47,6 +47,8 @@
       (.setTranscoder cfb (SerializingTranscoder.)))
     (when auth-descriptor
       (.setAuthDescriptor cfb auth-descriptor))
+    (when timeout-exception-threshold
+      (.setTimeoutExceptionThreshold cfb timeout-exception-threshold))
     ;; ConnectionFactoryBuilder will use various CF properties
     ;; from the argument you give it but protocol is not one of
     ;; them, so we set it up here explicitly. MK.


### PR DESCRIPTION
I came across this error: http://stackoverflow.com/questions/22332203/spymemcached-and-connection-failures

The default value in the java library seems to be 998 which seems kinda crazy to retry 998 times before retrying to connect.  Setting this value to a decent number helped us with fixing weird connection issues on long running processes with little/no activity for hours.