### PR TITLE
Expose underlying spymemcached futures

### DIFF
--- a/src/java/clojurewerkz/spyglass/BulkGetFuture.java
+++ b/src/java/clojurewerkz/spyglass/BulkGetFuture.java
@@ -16,6 +16,10 @@ import java.util.concurrent.TimeoutException;
 public class BulkGetFuture implements IDeref, IBlockingDeref{
   private net.spy.memcached.internal.BulkGetFuture bgf;
 
+  public net.spy.memcached.internal.BulkGetFuture getOriginalFuture() {
+    return this.bgf;
+  }
+
   public boolean cancel(boolean ign) {
     return bgf.cancel(ign);
   }

--- a/src/java/clojurewerkz/spyglass/GetFuture.java
+++ b/src/java/clojurewerkz/spyglass/GetFuture.java
@@ -19,6 +19,10 @@ public class GetFuture implements IDeref, IBlockingDeref{
     this.gf = gf;
   }
 
+  public net.spy.memcached.internal.GetFuture getOriginalFuture() {
+    return this.gf;
+  }
+
   public boolean cancel(boolean ign) {
     return gf.cancel(ign);
   }

--- a/test/clojurewerkz/spyglass/test/client_test.clj
+++ b/test/clojurewerkz/spyglass/test/client_test.clj
@@ -13,6 +13,12 @@
 
 (c/set-log-level! "WARNING")
 
+(deftest test-set-original-future
+  (let [^clojurewerkz.spyglass.OperationFuture set-future (c/set tc "s-key" 10 "s-value")
+        orig-future (.getOriginalFuture set-future)]
+    (is (instance? net.spy.memcached.internal.OperationFuture orig-future))
+    (is (= @set-future @orig-future))))
+
 (deftest test-set-then-get
   (testing "with the text protocol"
     (are [k v]
@@ -61,6 +67,11 @@
            "kw-key" :memcached
            "ratio-key" 3/8))))
 
+(deftest test-async-get-original-future
+  (let [async-get-future (c/async-get tc "s-key")
+        orig-future (.getOriginalFuture async-get-future)]
+    (is (instance? net.spy.memcached.internal.GetFuture orig-future))
+    (is (= @async-get-future @orig-future))))
 
 (deftest test-set-then-touch
   (testing "with the text protocol"
@@ -117,6 +128,12 @@
       (c/set bc "key2" 20 "b-value")
       (c/set bc "key3" 20 "c-value")
       (is (= {"key3" "c-value", "key2" "b-value", "key1" "a-value"} @(c/async-get-multi bc ["key1" "key2" "key3"]))))))
+
+(deftest test-async-multiget-original-future
+  (let [async-get-multi-future (c/async-get-multi tc ["key1" "key2"])
+        orig-future (.getOriginalFuture async-get-multi-future)]
+    (is (instance? net.spy.memcached.internal.BulkGetFuture orig-future))
+    (is (= @async-get-multi-future @orig-future))))
 
 (deftest test-gets-key-that-does-not-exist
   (testing "with the text protocol"


### PR DESCRIPTION
This change enables fully aynchronous workflows (i.e. no blocking
derefs) by exposing a .getOriginalFuture method on each Spyglass future
wrapper class, which allow consumers to attach listeners.